### PR TITLE
CI: Replace downloading and installing of Isabelle by separate action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,16 +19,12 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Download and install Isabelle
-        run: |
-          wget --quiet https://isabelle.in.tum.de/website-Isabelle2024/dist/Isabelle2024_linux.tar.gz -O isabelle.tar.gz
-          mkdir -p isabelle
-          tar -xzf isabelle.tar.gz -C isabelle --strip-components=1
-          rm isabelle.tar.gz
-          isabelle/bin/isabelle version
-          echo isabelle/bin >> $GITHUB_PATH
+      - name: Set up Isabelle
+        uses: gauravpartha/setup-isabelle@v1
+        with: 
+          isabelle-version: 2024
 
-      - name: Setup Isabelle sessions
+      - name: Set up Isabelle sessions
         run: |
           isabelle components -u foundational-boogie/BoogieLang
           isabelle components -u vipersemcommon

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,9 @@ jobs:
         with: 
           isabelle-version: 2024
 
+      - name: Isabelle version
+        run: isabelle version
+
       - name: Set up Isabelle sessions
         run: |
           isabelle components -u foundational-boogie/BoogieLang


### PR DESCRIPTION
Since the dedicated [action](https://github.com/gauravpartha/setup-isabelle) for setting up Isabelle implements caching of Isabelle, Isabelle need not be re-downloaded on every run (which led to issues in the past).